### PR TITLE
Remove link to perlcritic.com from workshop notes

### DIFF
--- a/_posts/2009-03-11-workshop.md
+++ b/_posts/2009-03-11-workshop.md
@@ -888,7 +888,7 @@ Continous build: suggest moving to system like Hudson
 Coding standards and development guidelines
 
 -   Good documents from Luis but nothing to enforce them
--   Should start at running \[<http://perlcritic.com> Perl::Critic\]:
+-   Should start at running Perl::Critic:
     highly configurable, large set of code checks, possibility to
     include project specific requirements
 


### PR DESCRIPTION
This unofficial site is gone and the reference to it was causing a
validation failure.
